### PR TITLE
Allow to build only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ solc
 coverage/
 coverage.json
 yarn-error.log
+templates/

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@gnosis.pm/safe-contracts": "1.3.0",
-    "@gnosis.pm/safe-deployments": "1.2.0",
+    "@gnosis.pm/safe-deployments": "1.5.0",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@types/mocha": "^8.2.0",
     "@types/yargs": "^15.0.10",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/mocha": "^8.2.0",
     "@types/yargs": "^15.0.10",
     "argv": "^0.0.2",
+    "csv-parser": "^3.0.0",
     "dotenv": "^8.0.0",
     "ethers": "^5.1.0",
     "hardhat": "^2.1.2",

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,5 +1,5 @@
 import { Contract } from "@ethersproject/contracts";
-import { getCompatibilityFallbackHandlerDeployment, getMultiSendDeployment, getProxyFactoryDeployment, getSafeSingletonDeployment, getSafeL2SingletonDeployment, SingletonDeployment } from "@gnosis.pm/safe-deployments";
+import { getCompatibilityFallbackHandlerDeployment, getMultiSendDeployment, getProxyFactoryDeployment, getSafeSingletonDeployment, getSafeL2SingletonDeployment, SingletonDeployment, getMultiSendCallOnlyDeployment } from "@gnosis.pm/safe-deployments";
 import { HardhatRuntimeEnvironment as HRE } from "hardhat/types";
 
 export const contractFactory = (hre: HRE, contractName: string) => hre.ethers.getContractFactory(contractName);
@@ -22,6 +22,9 @@ export const proxyFactory = async (hre: HRE, address?: string) =>
 
 export const multiSendLib = async (hre: HRE, address?: string) =>
     contractInstance(hre, getMultiSendDeployment(), address)
+
+export const multiSendCallOnlyLib = async (hre: HRE, address?: string) =>
+    contractInstance(hre, getMultiSendCallOnlyDeployment(), address)
 
 export const compatHandler = async (hre: HRE, address?: string) =>
     contractInstance(hre, getCompatibilityFallbackHandlerDeployment(), address)

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -10,6 +10,7 @@ const parseSigners = (rawSigners: string): string[] => {
 
 task("create", "Create a Safe")
     .addFlag("l2", "Should use version of the Safe contract that is more event heave")
+    .addFlag("buildOnly", "Indicate wether this transaction should only be logged and not submitted on-chain")
     .addParam("signers", "Comma separated list of signer addresses (dafault is the address of linked account)", "", types.string, true)
     .addParam("threshold", "Threshold that should be used", 1, types.int, true)
     .addParam("fallback", "Fallback handler address", AddressZero, types.string, true)
@@ -27,7 +28,13 @@ task("create", "Create a Safe")
         )
         const predictedAddress = await calculateProxyAddress(factory, singleton.address, setupData, taskArgs.nonce)
         console.log(`Deploy Safe to ${predictedAddress}`)
-        await factory.createProxyWithNonce(singleton.address, setupData, taskArgs.nonce).then((tx: any) => tx.wait())
+        console.log(`Singleton: ${singleton.address}`)
+        console.log(`Setup data: ${setupData}`)
+        console.log(`Nonce: ${taskArgs.nonce}`)
+        console.log(`To (factory): ${factory.address}`)
+        console.log(`Data: ${factory.interface.encodeFunctionData("createProxyWithNonce", [singleton.address, setupData, taskArgs.nonce])}`)
+        if (!taskArgs.buildOnly)
+            await factory.createProxyWithNonce(singleton.address, setupData, taskArgs.nonce).then((tx: any) => tx.wait())
         // TODO verify deployment
     });
 

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -85,7 +85,10 @@ task("create-bulk", "Create multiple Safes from CSV")
             const calculatedAddress = await calculateProxyAddress(factory, singleton.address, setupData.data, taskArgs.nonce)
             console.log(`   Address:`, calculatedAddress)
             if (setupData.expectedAddress && setupData.expectedAddress !== calculatedAddress)
-                console.warn(`      Unexpected Safe address! Expected ${setupData.expectedAddress}.`)
+                console.log(`      Unexpected Safe address! Expected ${setupData.expectedAddress}.`)
+            const onChainCode = await hre.ethers.provider.getCode(calculatedAddress)
+            if (onChainCode !== "0x")
+                console.log(`      Safe already exists on this address.`)
             console.log()
         }
 

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -11,7 +11,7 @@ const parseSigners = (rawSigners: string): string[] => {
 
 task("create", "Create a Safe")
     .addFlag("l2", "Should use version of the Safe contract that is more event heave")
-    .addFlag("buildOnly", "Indicate wether this transaction should only be logged and not submitted on-chain")
+    .addFlag("buildOnly", "Indicate whether this transaction should only be logged and not submitted on-chain")
     .addParam("signers", "Comma separated list of signer addresses (dafault is the address of linked account)", "", types.string, true)
     .addParam("threshold", "Threshold that should be used", 1, types.int, true)
     .addParam("fallback", "Fallback handler address", AddressZero, types.string, true)
@@ -40,7 +40,7 @@ task("create", "Create a Safe")
     });
 
 task("create-bulk", "Create multiple Safes from CSV")
-    .addFlag("buildOnly", "Indicate wether this transaction should only be logged and not submitted on-chain")
+    .addFlag("buildOnly", "Indicate whether this transaction should only be logged and not submitted on-chain")
     .addPositionalParam("csv", "CSV file with the information of the Safes that should be created", undefined, types.inputFile)
     .addParam("fallback", "Fallback handler address", undefined, types.string, true)
     .addParam("nonce", "Nonce used with factory", "0", types.string, true)

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -1,8 +1,9 @@
 import { task, types } from "hardhat/config";
 import { AddressZero } from "@ethersproject/constants";
 import { getAddress } from "@ethersproject/address";
-import { calculateProxyAddress } from "@gnosis.pm/safe-contracts";
-import { safeSingleton, proxyFactory, safeL2Singleton } from "./contracts";
+import { buildMultiSendSafeTx, calculateProxyAddress, encodeMultiSend, MetaTransaction } from "@gnosis.pm/safe-contracts";
+import { safeSingleton, proxyFactory, safeL2Singleton, multiSendCallOnlyLib, compatHandler } from "./contracts";
+import { readCsv, writeJson, writeTxBuilderJson } from "./execution/utils";
 
 const parseSigners = (rawSigners: string): string[] => {
     return rawSigners.split(",").map(address => getAddress(address))
@@ -35,6 +36,51 @@ task("create", "Create a Safe")
         console.log(`Data: ${factory.interface.encodeFunctionData("createProxyWithNonce", [singleton.address, setupData, taskArgs.nonce])}`)
         if (!taskArgs.buildOnly)
             await factory.createProxyWithNonce(singleton.address, setupData, taskArgs.nonce).then((tx: any) => tx.wait())
+        // TODO verify deployment
+    });
+
+task("create-bulk", "Create multiple Safes from CSV")
+    .addFlag("buildOnly", "Indicate wether this transaction should only be logged and not submitted on-chain")
+    .addPositionalParam("csv", "CSV file with the information of the Safes that should be created", undefined, types.inputFile)
+    .addParam("fallback", "Fallback handler address", undefined, types.string, true)
+    .addParam("nonce", "Nonce used with factory", "0", types.string, true)
+    .addParam("singleton", "Set to overwrite which singleton address to use", "", types.string, true)
+    .addParam("factory", "Set to overwrite which factory address to use", "", types.string, true)
+    .addFlag("l2", "Should use version of the Safe contract that is more event heave")
+    .addParam("export", "If specified instead of executing the data will be exported as a json file for the transaction builder", undefined, types.string)
+    .setAction(async (taskArgs, hre) => {
+        const singleton = taskArgs.l2 ? await safeL2Singleton(hre, taskArgs.singleton) : await safeSingleton(hre, taskArgs.singleton)
+        const factory = await proxyFactory(hre, taskArgs.factory)
+        const fallbackHandler = await compatHandler(hre, taskArgs.fallback)
+
+        const inputs: { threshold: string, signers: string }[] = await readCsv(taskArgs.csv)
+        const encodedSetups: string[] = inputs.filter(entry => entry.signers.trim().length !== 0).map(entry => {
+            const parsedThreshold = entry.threshold.split("/")[0]
+            const expectedSignerCount = entry.threshold.split("/")[1]
+            const parsedSigners = entry.signers.replace(/\n/g,",").split(",")
+            console.log({parsedThreshold, expectedSignerCount, parsedSigners})
+            if (expectedSignerCount && parseInt(expectedSignerCount) !== parsedSigners.length) throw Error(`Expected ${expectedSignerCount} Signers, got ${parsedSigners}`)
+            return singleton.interface.encodeFunctionData(
+                "setup",
+                [parsedSigners, parsedThreshold, AddressZero, "0x", fallbackHandler.address, AddressZero, 0, AddressZero]
+            )
+        })
+        const deploymentTxs: MetaTransaction[] = encodedSetups.map(setup => {
+            const data = factory.interface.encodeFunctionData("createProxyWithNonce", [singleton.address, setup, taskArgs.nonce])
+            return { to: factory.address, data, operation: 0, value: "0" }
+        })
+        const multiSend = await multiSendCallOnlyLib(hre)
+        console.log(`Singleton: ${singleton.address}`)
+        console.log(`Nonce: ${taskArgs.nonce}`)
+        console.log(`Factory: ${factory.address}`)
+        console.log(`Data: ${multiSend.interface.encodeFunctionData("multiSend", [encodeMultiSend(deploymentTxs)])}`)
+
+        if (taskArgs.export) {
+            const chainId = (await hre.ethers.provider.getNetwork()).chainId.toString()
+            await writeTxBuilderJson(taskArgs.export, chainId, deploymentTxs, "Batched Safe Creations")
+        } else if (!taskArgs.buildOnly) {
+            await multiSend.multiSend(encodeMultiSend(deploymentTxs)).then((tx: any) => tx.wait())
+        }
         // TODO verify deployment
     });
 

--- a/src/execution/proposing.ts
+++ b/src/execution/proposing.ts
@@ -90,6 +90,7 @@ const parseMultiSendJsonFile = async (hre: HardhatRuntimeEnvironment, file: stri
 task("propose-multi", "Create a Safe tx proposal json file")
     .addPositionalParam("address", "Address or ENS name of the Safe to check", undefined, types.string)
     .addPositionalParam("txs", "Json file with transactions", undefined, types.inputFile)
+    .addParam("nonce", "Set nonce to use (will default to on-chain nonce)", "", types.string, true)
     .addFlag("onChainHash", "Get hash from chain (required for pre-1.3.0 version)")
     .addParam("multiSend", "Set to overwrite which multiSend address to use", "", types.string, true)
     .setAction(async (taskArgs, hre) => {
@@ -97,8 +98,8 @@ task("propose-multi", "Create a Safe tx proposal json file")
         const safe = await safeSingleton(hre, taskArgs.address)
         const safeAddress = await safe.resolvedAddress
         console.log(`Using Safe at ${safeAddress}`)
-        const nonce = await safe.nonce()
-        const tx = await parseMultiSendJsonFile(hre, taskArgs.txs, nonce.toNumber(), taskArgs.multiSend)
+        const nonce = taskArgs.nonce || await safe.nonce()
+        const tx = await parseMultiSendJsonFile(hre, taskArgs.txs, BigNumber.from(nonce).toNumber(), taskArgs.multiSend)
         console.log("Safe transaction", tx)
         const chainId = (await safe.provider.getNetwork()).chainId
         const safeTxHash = await calcSafeTxHash(safe, tx, chainId, taskArgs.onChainHash)

--- a/src/execution/simple.ts
+++ b/src/execution/simple.ts
@@ -1,6 +1,6 @@
 import { task, types } from "hardhat/config";
 
-task("simple-submit-proposal", "Executes a Safe transaction from a file")
+task("submit-multi", "Executes a Safe transaction from a file")
     .addPositionalParam("address", "Address or ENS name of the Safe to check", undefined, types.string)
     .addPositionalParam("txs", "Json file with transactions", undefined, types.inputFile)
     .addFlag("onChainHash", "Get hash from chain (required for pre-1.3.0 version)")
@@ -9,6 +9,7 @@ task("simple-submit-proposal", "Executes a Safe transaction from a file")
     .addParam("signatures", "Comma seperated list of signatures", undefined, types.string, true)
     .addParam("gasPrice", "Gas price to be used", undefined, types.int, true)
     .addParam("gasLimit", "Gas limit to be used", undefined, types.int, true)
+    .addFlag("buildOnly", "Flag to only output the final transaction")
     .setAction(async (taskArgs, hre) => {
         const safeTxHash = await hre.run("propose-multi", {
             address: taskArgs.address,
@@ -22,5 +23,6 @@ task("simple-submit-proposal", "Executes a Safe transaction from a file")
             signerIndex: taskArgs.signerIndex,
             signatures: taskArgs.signatures,
             gasLimit: taskArgs.gasLimit,
+            buildOnly: taskArgs.buildOnly,
         })
     });

--- a/src/execution/submitting.ts
+++ b/src/execution/submitting.ts
@@ -112,6 +112,7 @@ task("submit-proposal", "Executes a Safe transaction")
     .addParam("signatures", "Comma seperated list of signatures", undefined, types.string, true)
     .addParam("gasPrice", "Gas price to be used", undefined, types.int, true)
     .addParam("gasLimit", "Gas limit to be used", undefined, types.int, true)
+    .addFlag("buildOnly", "Flag to only output the final transaction")
     .setAction(async (taskArgs, hre) => {
         console.log(`Running on ${hre.network.name}`)
         const proposal: SafeTxProposal = await readFromCliCache(proposalFile(taskArgs.hash))
@@ -131,6 +132,12 @@ task("submit-proposal", "Executes a Safe transaction")
         }
         const signatures = await prepareSignatures(safe, proposal.tx, signatureArray.join(","), signer, taskArgs.hash)
         const populatedTx: PopulatedTransaction = await populateExecuteTx(safe, proposal.tx, signatures, { gasLimit: taskArgs.gasLimit, gasPrice: taskArgs.gasPrice })
+        
+        if (taskArgs.buildOnly) {
+            console.log("Ethereum transaction:", populatedTx)
+            return
+        }
+        
         const receipt = await signer.sendTransaction(populatedTx).then(tx => tx.wait())
         console.log("Ethereum transaction hash:", receipt.transactionHash)
         return receipt.transactionHash

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -1,5 +1,8 @@
 import path from 'path'
 import fs from 'fs/promises'
+import fsSync from 'fs'
+import csvParser from "csv-parser"
+import { MetaTransaction } from '@gnosis.pm/safe-contracts'
 
 const cliCacheDir = "cli_cache"
 
@@ -16,6 +19,23 @@ export const writeToCliCache = async(key: string, content: any) => {
     await fs.writeFile(path.join(folder, key), JSON.stringify(content, null, 2))
 }
 
+export const writeJson = async(file: string, content: any) => {
+    await fs.writeFile(file, JSON.stringify(content, null, 2))
+}
+
+export const writeTxBuilderJson = async(file: string, chainId: string, transactions: MetaTransaction[], name?: string, description?: string) => {
+    return writeJson(file, {
+        version: "1.0",
+        chainId,
+        createdAt: new Date().getTime(),
+        meta: {
+            name,
+            description
+        },
+        transactions
+    })
+}
+
 export const readFromCliCache = async(key: string): Promise<any> => {
     const content = await fs.readFile(path.join(process.cwd(), cliCacheDir, key), 'utf8')
     return JSON.parse(content)
@@ -28,3 +48,11 @@ export const loadSignatures = async(safeTxHash: string): Promise<Record<string, 
         return {}
     }
 }
+
+export const readCsv = async<T>(file: string): Promise<T[]> => new Promise((resolve, reject) => {
+    const results: T[] = [];
+    fsSync.createReadStream(file).pipe(csvParser())
+        .on("data", (data) => results.push(data))
+        .on("error", (err) => { reject(err) })
+        .on("end", () => { resolve(results)})
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,10 +381,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
   integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
 
-"@gnosis.pm/safe-deployments@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.2.0.tgz#cf3aa9c2c15ca49459e5a90cbe702127528bbacd"
-  integrity sha512-xvfIhpOrCsdN7pkTtq6xl8pYbwXdkx3MTRh4cq3ucNDyw2dPJCYDr7gI6FPJ79jZiUkWwQzXzlxiEieuv6Dhpw==
+"@gnosis.pm/safe-deployments@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.5.0.tgz#5e01ccc2e2d78bf91ecb4453a64d1cac3a5ba2d6"
+  integrity sha512-IDU7I+IQr1zUU94/uD8shDVI+/nUA1unQUg8jtbTG0YGcmm49Lu8G01rqtWt2mhLxZWzFsgbLWGnU+/BzUqk7g==
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,6 +1211,13 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+csv-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/csv-parser/-/csv-parser-3.0.0.tgz#b88a6256d79e090a97a1b56451f9327b01d710e7"
+  integrity sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==
+  dependencies:
+    minimist "^1.2.0"
+
 debug@3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"


### PR DESCRIPTION
- added option to only build the data and not submit on-chain
- added option to export transactions so that it can be imported into the transaction builder safe app
- added tasks to bulk create Safes from csv file