### PR TITLE
Change "signerIndex" parameter to "signer"

### DIFF
--- a/src/execution/signing.ts
+++ b/src/execution/signing.ts
@@ -11,12 +11,12 @@ task("sign-tx", "Signs a Safe transaction")
     .addParam("to", "Address of the target", undefined, types.string)
     .addParam("value", "Value in ETH", "0", types.string, true)
     .addParam("data", "Data as hex string", "0x", types.string, true)
-    .addParam("signerIndex", "Index of the signer to use", 0, types.int, true)
+    .addParam("signer", "Index of the signer to use", 0, types.int, true)
     .addFlag("delegatecall", "Indicator if tx should be executed as a delegatecall")
     .setAction(async (taskArgs, hre) => {
         console.log(`Running on ${hre.network.name}`)
         const signers = await hre.ethers.getSigners()
-        const signer = signers[taskArgs.signerIndex]
+        const signer = signers[taskArgs.signer]
         const safe = await safeSingleton(hre, taskArgs.address)
         const safeAddress = await safe.resolvedAddress
         console.log(`Using Safe at ${safeAddress} with ${signer.address}`)
@@ -35,11 +35,11 @@ const updateSignatureFile = async(safeTxHash: string, signature: SafeSignature) 
 
 task("sign-proposal", "Signs a Safe transaction")
     .addPositionalParam("hash", "Hash of Safe transaction to display", undefined, types.string)
-    .addParam("signerIndex", "Index of the signer to use", 0, types.int, true)
+    .addParam("signer", "Index of the signer to use", 0, types.int, true)
     .setAction(async (taskArgs, hre) => {
         const proposal: SafeTxProposal = await readFromCliCache(proposalFile(taskArgs.hash))
         const signers = await hre.ethers.getSigners()
-        const signer = signers[taskArgs.signerIndex]
+        const signer = signers[taskArgs.signer]
         const safe = await safeSingleton(hre, proposal.safe)
         const safeAddress = await safe.resolvedAddress
         console.log(`Using Safe at ${safeAddress} with ${signer.address}`)

--- a/src/execution/simple.ts
+++ b/src/execution/simple.ts
@@ -5,7 +5,7 @@ task("submit-multi", "Executes a Safe transaction from a file")
     .addPositionalParam("txs", "Json file with transactions", undefined, types.inputFile)
     .addFlag("onChainHash", "Get hash from chain (required for pre-1.3.0 version)")
     .addParam("multiSend", "Set to overwrite which multiSend address to use", "", types.string, true)
-    .addParam("signerIndex", "Index of the signer to use", 0, types.int, true)
+    .addParam("signer", "Index of the signer to use", 0, types.int, true)
     .addParam("signatures", "Comma seperated list of signatures", undefined, types.string, true)
     .addParam("gasPrice", "Gas price to be used", undefined, types.int, true)
     .addParam("gasLimit", "Gas limit to be used", undefined, types.int, true)
@@ -20,7 +20,7 @@ task("submit-multi", "Executes a Safe transaction from a file")
         await hre.run("submit-proposal", {
             hash: safeTxHash,
             onChainHash: taskArgs.onChainHash,
-            signerIndex: taskArgs.signerIndex,
+            signer: taskArgs.signer,
             signatures: taskArgs.signatures,
             gasLimit: taskArgs.gasLimit,
             buildOnly: taskArgs.buildOnly,

--- a/src/execution/submitting.ts
+++ b/src/execution/submitting.ts
@@ -108,7 +108,7 @@ task("submit-tx", "Executes a Safe transaction")
 
 task("submit-proposal", "Executes a Safe transaction")
     .addPositionalParam("hash", "Hash of Safe transaction to display", undefined, types.string)
-    .addParam("signerIndex", "Index of the signer to use", 0, types.int, true)
+    .addParam("signer", "Index of the signer to use", 0, types.int, true)
     .addParam("signatures", "Comma seperated list of signatures", undefined, types.string, true)
     .addParam("gasPrice", "Gas price to be used", undefined, types.int, true)
     .addParam("gasLimit", "Gas limit to be used", undefined, types.int, true)
@@ -117,7 +117,7 @@ task("submit-proposal", "Executes a Safe transaction")
         console.log(`Running on ${hre.network.name}`)
         const proposal: SafeTxProposal = await readFromCliCache(proposalFile(taskArgs.hash))
         const signers = await hre.ethers.getSigners()
-        const signer = signers[taskArgs.signerIndex]
+        const signer = signers[taskArgs.signer]
         const safe = await safeSingleton(hre, proposal.safe)
         const safeAddress = await safe.resolvedAddress
         console.log(`Using Safe at ${safeAddress} with ${signer.address}`)


### PR DESCRIPTION
When specifying signers for `yarn safe sign-proposal` we receive the error:

[Error HH310](https://hardhat.org/hardhat-runner/docs/errors#HH310): Invalid param --signerIndex. Command line params must be lowercase.

For example:
``
yarn safe sign-proposal 0xb48adaaba46d0c8287fb59be84905bcd0e0a99652183180bdfa49bca6ad856a9 --signerIndex 1
``

replacing instances of `signerIndex` with `signer` fixes this

New command syntax:
``
yarn safe sign-proposal 0xb48adaaba46d0c8287fb59be84905bcd0e0a99652183180bdfa49bca6ad856a9 --signer 1
``